### PR TITLE
Allow exclusion of a model prop in migration generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,11 +333,19 @@ models:
           type: string
           enum: ['Male', 'Female', 'Other']
           default: 'Female'
+        favFood:
+          type: string
+          enum: ['pine-apple', 'blueBerry', 'cheese_pizza']
+        childrenCount:
+          type: number
+          default: 0
         username:
           allOf:
             # combine a ref and a non-ref, see json schema spec for more info
             - $ref: '#/components/fieldProperties/username'
             - default: 'default-user'
+        someOtherField:
+          type: string
         created:
           type: string
           format: date-time
@@ -375,6 +383,11 @@ models:
           # columns to index
           # values will always be converted to snake case
           columns: ['age', 'name']
+      exclude:
+        # exclude these fields from being generated in the migration file
+        # this is if you want to have a field defined in the model
+        # but not in the database
+        columns: ['someOtherField']
   Movie:
     tableName: movies
     jsonSchema:

--- a/sample.yaml
+++ b/sample.yaml
@@ -41,6 +41,8 @@ models:
             # combine a ref and a non-ref, see json schema spec for more info
             - $ref: '#/components/fieldProperties/username'
             - default: 'default-user'
+        someOtherField:
+          type: string
         created:
           type: string
           format: date-time
@@ -78,6 +80,11 @@ models:
           # columns to index
           # values will always be converted to snake case
           columns: ['age', 'name']
+      exclude:
+        # exclude these fields from being generated in the migration file
+        # this is if you want to have a field defined in the model
+        # but not in the database
+        columns: ['someOtherField']
   Movie:
     tableName: movies
     jsonSchema:

--- a/src/__fixtures__/column-exclusion.json
+++ b/src/__fixtures__/column-exclusion.json
@@ -48,6 +48,11 @@
           }
         }
       },
+      "database": {
+        "exclude": {
+          "columns": ["excludedField"]
+        }
+      },
       "relations": {
         "movies": {
           "relation": "Model.ManyToManyRelation",

--- a/src/generators/__tests__/__snapshots__/knex.test.ts.snap
+++ b/src/generators/__tests__/__snapshots__/knex.test.ts.snap
@@ -8,6 +8,47 @@ exports[`KnexGenerator class should generate a migration 1`] = `
     table.integer('age')
     table.enu('gender', ['Male', 'Female', 'Other']).defaultTo('Female')
     table.string('username', 25).notNullable()
+    table.string('excluded_field')
+
+    table.primary(['id'])
+  })
+  await knex.schema.createTable('movies', table => {
+    table.string('id')
+    table.string('name', 255).notNullable()
+
+    table.primary(['id'])
+  })
+  await knex.schema.createTable('reviews', table => {
+    table.string('review_id')
+    table.string('author_id').notNullable()
+    table.string('movie_id').notNullable()
+    table.string('content')
+
+    table.primary(['review_id'])
+  })
+}
+
+async function down (knex) {
+  await knex.schema.dropTable('persons')
+  await knex.schema.dropTable('movies')
+  await knex.schema.dropTable('reviews')
+}
+
+module.exports = {
+  up,
+  down
+}
+"
+`;
+
+exports[`KnexGenerator class should generate a migration with a field excluded 1`] = `
+"async function up (knex) {
+  await knex.schema.createTable('persons', table => {
+    table.string('id')
+    table.string('name', 100).notNullable()
+    table.integer('age')
+    table.enu('gender', ['Male', 'Female', 'Other']).defaultTo('Female')
+    table.string('username', 25).notNullable()
 
     table.primary(['id'])
   })

--- a/src/generators/__tests__/__snapshots__/objection.test.ts.snap
+++ b/src/generators/__tests__/__snapshots__/objection.test.ts.snap
@@ -18,6 +18,7 @@ export class PersonModel extends BaseModel {
   age: number | null
   gender: PersonGenderEnum
   username: string
+  excludedField: string
 
   static tableName = 'persons'
 
@@ -47,6 +48,9 @@ export class PersonModel extends BaseModel {
           minLength: 1,
           maxLength: 25,
           nullable: false
+        },
+        excludedField: {
+          type: 'string'
         }
       }
     }

--- a/src/generators/__tests__/knex.test.ts
+++ b/src/generators/__tests__/knex.test.ts
@@ -4,6 +4,7 @@ import { pathExistsSync, remove } from 'fs-extra'
 import { readFileSync } from 'fs'
 import { resolve } from 'path'
 import validConfig from '../../__fixtures__/valid-config.json'
+import excludedColConfig from '../../__fixtures__/column-exclusion.json'
 
 import { KnexGenerator } from '../knex'
 import { YamlConfig } from '../../interfaces'
@@ -20,6 +21,22 @@ describe('KnexGenerator class', () => {
   it('should generate a migration', async () => {
     const generator = new KnexGenerator(
       (validConfig as unknown) as YamlConfig,
+      templateDir + '/knex',
+      OUT_DIR
+    )
+
+    await generator.init()
+    await generator.generate()
+
+    const migrationPath = resolve(OUT_DIR, 'migrations', '000-init.js')
+
+    expect(pathExistsSync(migrationPath)).toBe(true)
+    expect(readFileSync(migrationPath, 'utf8')).toMatchSnapshot()
+  })
+
+  it('should generate a migration with a field excluded', async () => {
+    const generator = new KnexGenerator(
+      (excludedColConfig as unknown) as YamlConfig,
       templateDir + '/knex',
       OUT_DIR
     )

--- a/src/schema-validator/model/database.validator.ts
+++ b/src/schema-validator/model/database.validator.ts
@@ -33,11 +33,25 @@ const indexValidator = {
   }
 }
 
+// for excluding columns in knex generation
+const exclusionValidator = {
+  type: 'object',
+  properties: {
+    columns: {
+      type: 'array',
+      items: {
+        type: 'string'
+      }
+    }
+  }
+}
+
 export const modelDatabaseValidator = {
   type: 'object',
   additionalProperties: false,
   properties: {
     unique: uniqueValidator,
-    index: indexValidator
+    index: indexValidator,
+    exclude: exclusionValidator
   }
 }

--- a/src/templates/knex/.helpers/all.js
+++ b/src/templates/knex/.helpers/all.js
@@ -68,6 +68,21 @@ module.exports = (Handlebars, _) => {
     }
   })
 
+  /**
+   * Checks if a value is not in an array
+   */
+  Handlebars.registerHelper('notInArray', (context, field, required = [], options) => {
+    if (Array.isArray(required) && required.includes(field)) {
+      return options.inverse(context);
+    }
+
+    return options.fn(context);
+  })
+
+  Handlebars.registerHelper('stringify', (obj = {}) => {
+    return JSON.stringify(obj)
+  });
+
   Handlebars.registerHelper('addDefault', (columnProps) => {
     if (columnProps.default !== undefined) {
       switch (columnProps.type) {

--- a/src/templates/knex/migrations/000-init.hbs
+++ b/src/templates/knex/migrations/000-init.hbs
@@ -2,7 +2,9 @@ async function up(knex) {
 {{#each models}}
   await knex.schema.createTable('{{{tableName}}}', (table) => {
     {{#each jsonSchema.properties}}
+      {{#notInArray . @key ../database.exclude.columns}}
       {{{defineDbCol @key .}}}{{{addRequired @key ..}}}{{{addDefault .}}}
+      {{/notInArray}}
     {{/each}}
 
     {{#if idColumn}}


### PR DESCRIPTION
This adds a new field, `database.exclude.columns`, which when specified, will exclude the list of fields from being generated in the migration file. This allows you to keep a property as part of a model, but not in the migration.